### PR TITLE
Fix code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/github/joaoh4547/rhsystem/rhsystemapi/config/SecurityConfig.java
+++ b/src/main/java/com/github/joaoh4547/rhsystem/rhsystemapi/config/SecurityConfig.java
@@ -20,7 +20,6 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable);
         http.cors(cors -> {
             cors.configurationSource(corsConfigurationSource());
         });


### PR DESCRIPTION
Fixes [https://github.com/joaoh4547/rh-system-api/security/code-scanning/1](https://github.com/joaoh4547/rh-system-api/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This involves removing the line that disables CSRF protection (`http.csrf(AbstractHttpConfigurer::disable)`) and allowing the default CSRF protection to be applied. This change ensures that the application is protected against CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
